### PR TITLE
Remove unnecessary conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ const clipboard = navigator.clipboard ? navigator.clipboard : clipboardPolyfill;
 
 const readText = () => clipboard.readText();
 
-const read = () =>
-  clipboard.read ? clipboard.read() : clipboardPolyfill.read();
+const read = () => clipboard.read();
 
 const writeText = text => clipboard.writeText(text);
 


### PR DESCRIPTION
The `clipboard` const alredy has `read()` method, then you don't need this conditional.

```js
const read = () => clipboard.read ? clipboard.read() : clipboardPolyfill.read();
```

